### PR TITLE
[scag] Add option to switch between Gramine repositories

### DIFF
--- a/Documentation/manpages/scag-setup.rst
+++ b/Documentation/manpages/scag-setup.rst
@@ -27,6 +27,10 @@ Options
     Initialize an empty directory with an example application from
     the given framework.
 
+.. option:: --gramine_unstable
+
+   Use a pre-release version of Gramine.
+
 .. option:: --framework <framework>
 
     The framework used by the scaffolded application.
@@ -120,6 +124,7 @@ Example of the generated file (from
 
     [gramine]
     passthrough_env = []
+    gramine_unstable = false
 
     [python_plain]
     application = "hello_world.py"

--- a/graminescaffolding/__main__.py
+++ b/graminescaffolding/__main__.py
@@ -136,11 +136,15 @@ def setup_handle_project_dir(ctx, project_dir, bootstrap):
     help='The directory of the application to scaffold.')
 @gramine_option_prompt('--bootstrap', required=False, is_flag=True,
     default=False, help='Bootstrap directory with framework example.')
+@gramine_option_prompt('--gramine_unstable', required=False, is_flag=True,
+    default=False, help='Use gramine unstable repo.')
 @gramine_option_prompt('--passthrough_env', required=False, multiple=True,
     help='List of passthrough environment variables.')
 @click.argument('args', nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
-def setup(ctx, framework, project_dir, bootstrap, passthrough_env, args):
+def setup(ctx, framework, project_dir, bootstrap, gramine_unstable,
+    passthrough_env, args
+):
     """
     Build Gramine application using Scaffolding framework.
 
@@ -155,7 +159,8 @@ def setup(ctx, framework, project_dir, bootstrap, passthrough_env, args):
         ctx.fail(f'{err}')
 
     framework = gramine_load_framework(framework)
-    parser = framework.cmdline_setup_parser(project_dir, passthrough_env)
+    parser = framework.cmdline_setup_parser(
+        project_dir, gramine_unstable, passthrough_env)
     if bootstrap:
         if len(args) > 0:
             print(

--- a/graminescaffolding/builder.py
+++ b/graminescaffolding/builder.py
@@ -178,6 +178,8 @@ class Builder:
             types.MappingProxyType({}))
         templates.globals['passthrough_env'] = list(
             self.config['gramine'].get('passthrough_env', []))
+        templates.globals['gramine_unstable'] = self.config['gramine'].get(
+            'gramine_unstable', False)
 
         return templates
 
@@ -385,7 +387,7 @@ class Builder:
 
 
     @classmethod
-    def cmdline_setup_parser(cls, project_dir, passthrough_env):
+    def cmdline_setup_parser(cls, project_dir, gramine_unstable, passthrough_env):
         @click.command()
         def click_parser():
             return cls(project_dir, {
@@ -394,6 +396,7 @@ class Builder:
                 },
                 'gramine': {
                     'passthrough_env': passthrough_env,
+                    'gramine_unstable': gramine_unstable,
                 },
             })
         return click_parser
@@ -406,7 +409,7 @@ class PythonBuilder(Builder):
     )
 
     @classmethod
-    def cmdline_setup_parser(cls, project_dir, passthrough_env):
+    def cmdline_setup_parser(cls, project_dir, gramine_unstable, passthrough_env):
         @click.command()
         @utils.gramine_option_prompt('--application', type=str,
             required=True,
@@ -419,6 +422,7 @@ class PythonBuilder(Builder):
                 },
                 'gramine': {
                     'passthrough_env': passthrough_env,
+                    'gramine_unstable': gramine_unstable,
                 },
                 cls.framework: {
                     'application': application,
@@ -449,7 +453,7 @@ class NodejsBuilder(Builder):
     )
 
     @classmethod
-    def cmdline_setup_parser(cls, project_dir, passthrough_env):
+    def cmdline_setup_parser(cls, project_dir, gramine_unstable, passthrough_env):
         @click.command()
         @utils.gramine_option_prompt('--application', required=True, type=str,
             prompt="Which script is the main one")
@@ -460,6 +464,7 @@ class NodejsBuilder(Builder):
                 },
                 'gramine': {
                     'passthrough_env': passthrough_env,
+                    'gramine_unstable': gramine_unstable,
                 },
                 cls.framework: {
                     'application': application,
@@ -483,7 +488,7 @@ class ExpressjsBuilder(Builder):
     )
 
     @classmethod
-    def cmdline_setup_parser(cls, project_dir, passthrough_env):
+    def cmdline_setup_parser(cls, project_dir, gramine_unstable, passthrough_env):
         @click.command()
         @utils.gramine_option_prompt('--application', required=True, type=str,
             prompt="Which script is the main one")
@@ -494,6 +499,7 @@ class ExpressjsBuilder(Builder):
                 },
                 'gramine': {
                     'passthrough_env': passthrough_env,
+                    'gramine_unstable': gramine_unstable,
                 },
                 cls.framework: {
                     'application': application,
@@ -517,7 +523,7 @@ class KoajsBuilder(Builder):
     )
 
     @classmethod
-    def cmdline_setup_parser(cls, project_dir, passthrough_env):
+    def cmdline_setup_parser(cls, project_dir, gramine_unstable, passthrough_env):
         @click.command()
         @utils.gramine_option_prompt('--application', required=True, type=str,
             prompt="Which script is the main one")
@@ -528,6 +534,7 @@ class KoajsBuilder(Builder):
                 },
                 'gramine': {
                     'passthrough_env': passthrough_env,
+                    'gramine_unstable': gramine_unstable,
                 },
                 cls.framework: {
                     'application': application,
@@ -546,7 +553,7 @@ class JavaJARBuilder(Builder):
     )
 
     @classmethod
-    def cmdline_setup_parser(cls, project_dir, passthrough_env):
+    def cmdline_setup_parser(cls, project_dir, gramine_unstable, passthrough_env):
         @click.command()
         @utils.gramine_option_prompt('--application', required=True, type=str,
             prompt="Which JAR is the main one")
@@ -557,6 +564,7 @@ class JavaJARBuilder(Builder):
                 },
                 'gramine': {
                     'passthrough_env': passthrough_env,
+                    'gramine_unstable': gramine_unstable,
                 },
                 cls.framework: {
                     'application': application,
@@ -572,7 +580,7 @@ class JavaGradleBuilder(Builder):
     )
 
     @classmethod
-    def cmdline_setup_parser(cls, project_dir, passthrough_env):
+    def cmdline_setup_parser(cls, project_dir, gramine_unstable, passthrough_env):
         @click.command()
         @utils.gramine_option_prompt('--application', required=True, type=str,
             prompt="Which JAR is the main one")
@@ -583,6 +591,7 @@ class JavaGradleBuilder(Builder):
                 },
                 'gramine': {
                     'passthrough_env': passthrough_env,
+                    'gramine_unstable': gramine_unstable,
                 },
                 cls.framework: {
                     'application': application,
@@ -603,7 +612,7 @@ class DotnetBuilder(Builder):
     )
 
     @classmethod
-    def cmdline_setup_parser(cls, project_dir, passthrough_env):
+    def cmdline_setup_parser(cls, project_dir, gramine_unstable, passthrough_env):
         @click.command()
         @utils.gramine_option_prompt('--build_config', required=True,
             type=click.Choice(['Debug', 'Release']),
@@ -621,6 +630,7 @@ class DotnetBuilder(Builder):
                 },
                 'gramine': {
                     'passthrough_env': passthrough_env,
+                    'gramine_unstable': gramine_unstable,
                 },
                 cls.framework: {
                     'build_config': build_config,

--- a/graminescaffolding/templates/scag.toml
+++ b/graminescaffolding/templates/scag.toml
@@ -8,6 +8,7 @@ framework = "{{ scag.builder.framework }}"
 {% block gramine -%}
 [gramine]
 passthrough_env = {{ passthrough_env }}
+gramine_unstable = {{ gramine_unstable | lower }}
 {%- endblock %}
 
 [{{ scag.builder.framework }}]

--- a/graminescaffolding/templates/sources.list
+++ b/graminescaffolding/templates/sources.list
@@ -1,7 +1,7 @@
 {% block sources %}
 deb http://deb.debian.org/debian/ bookworm main
 deb http://security.debian.org/debian-security bookworm-security main
-deb https://packages.gramineproject.io/ bookworm main
+deb https://packages.gramineproject.io/ {% if gramine_unstable %}unstable-{% endif %}bookworm main
 deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main
 {% endblock %}
 

--- a/graminescaffolding/utils.py
+++ b/graminescaffolding/utils.py
@@ -56,7 +56,7 @@ class GramineExtendedSetupHelpFormatter(click.HelpFormatter):
 
         for name in gramine_list_frameworks():
             parser = gramine_load_framework(name).cmdline_setup_parser(
-                None, None)
+                None, False, None)
             self.indent()
             opts = []
             for param in parser.params:


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Gramine maintains two repositories: stable and unstable. The unstable repository is mostly used for testing release candidates. This commit adds an option to switch between these repositories.

Should fix #14 .

## How to test this PR? <!-- (if applicable) -->

While using `scag-setup` you can add `'--gramine_unstable` to use an unstable repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-scaffolding/15)
<!-- Reviewable:end -->
