### PR TITLE
Update install docs for <= Ubuntu 23 systems in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,17 +56,8 @@ Debian 11
     # gramine-sgx-gen-private-key # if you didn't already
     scag-quickstart
 
-Install into venv (for other distros, esp. for Ubuntu older than 23.04)
+Install with pipx (for other distros, esp. for Ubuntu older than 23.04)
 -----------------------------------------------------------------------
-
-Unlike previous instructions, which build and install Scaffolding for all users
-in the system, this stanza installs the project into python's virtual
-environment. Those work only for single user, and either:
-
-- each time you restart your shell, you need to source the ``activate`` script
-  again; or
-- call the binaries by their full path (e.g., ``.venv/bin/scag-build``); or
-- add venv's ``bin/`` directory to ``$PATH`` environment variable.
 
 First, install gramine as described in
 https://gramine.rtfd.io/en/stable/installation.html#install-gramine-packages .
@@ -81,10 +72,10 @@ Then:
 
 .. code-block:: sh
 
-    sudo apt-get install docker.io python3-pip mmdebstrap
-    python3 -m venv .venv
-    source .venv/bin/activate
-    python3 -m pip install .
+    sudo apt-get install docker.io python3-pip mmdebstrap pipx
+    pipx ensurepath
+    # reload your shell to let the future binaries be available
+    pipx install .
     scag-quickstart
 
 Development (editable install into virtualenv)


### PR DESCRIPTION
instead of creating a virtual environment, you can use pipx to let the python packages be available globally.

<!--
    Please fill in the following form before submitting this PR.
-->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

replaced the usage of pip and venv with pipx, because for this use-case that fits better

## How to test this PR? <!-- (if applicable) -->

Try it out on your own.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-scaffolding/17)
<!-- Reviewable:end -->
